### PR TITLE
Fix crash on subtask removal in editor

### DIFF
--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -732,7 +732,7 @@ class TaskEditor(Gtk.Window):
     def remove_subtask(self, tid):
         """Remove a subtask of this task."""
 
-        self.app.ds.tasks.unparent(tid, self.task.tid)
+        self.app.ds.tasks.unparent(tid, self.task.id)
 
     def rename_subtask(self, tid, new_title):
         """Rename a subtask of this task."""


### PR DESCRIPTION
Removing a subtask in the editor leads to a crash:

<pre>
**Context:** Global generic exception

```python-traceback
Traceback (most recent call last):
  File "/app/lib/python3.10/site-packages/GTG/gtk/editor/taskview.py", line 222, in process
    self.delete_subtask_cb(tid)
  File "/app/lib/python3.10/site-packages/GTG/gtk/editor/editor.py", line 735, in remove_subtask
    self.app.ds.tasks.unparent(tid, self.task.tid)
AttributeError: 'Task2' object has no attribute 'tid'
```

**Software versions:**
* Getting Things GNOME! v0.6-302-g4340e7bb
* CPython 3.10.12 (main, Nov 10 2011, 15:00:00) [GCC 12.2.0]
* GTK 4.10.4, GLib 2.76.3
* PyGLib 3.44.1, PyGObject 3.44.1
* Linux-6.4.4-200.fc38.x86_64-x86_64-with-glibc2.35
* Flatpak 1.15.4
* Flatpak runtime: runtime/org.gnome.Platform/x86_64/44 (584d7c3e03c7315975c6711d6503622c0b39c109b6faa89254a87d24cf918c6e)
* Flatpak app: org.gnome.GTGDevel (9a68c013e08ea50bccc8ad6f4c21e3d77c405592c517b8e2170005ddf9cb8981)
</pre>

This happens because of a false reference to the old `Task.tid` property.