### PR TITLE
Fix usage of Task2.id property

### DIFF
--- a/GTG/gtk/application.py
+++ b/GTG/gtk/application.py
@@ -413,7 +413,7 @@ class Application(Gtk.Application):
         search = self.browser.search_entry.is_focus()
 
         if editor:
-            self.close_task(editor.task.get_id())
+            self.close_task(editor.task.id)
         elif search:
             self.browser.toggle_search(action, params)
 

--- a/GTG/gtk/browser/main_window.py
+++ b/GTG/gtk/browser/main_window.py
@@ -1239,7 +1239,7 @@ class MainWindow(Gtk.ApplicationWindow):
         trace_subtasks(self.req.get_task(task_id))
 
         for task in all_subtasks:
-            self.app.close_task(task.get_id())
+            self.app.close_task(task.id)
 
 
     def on_mark_as_done(self, widget=None):

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -433,7 +433,7 @@ class TaskEditor(Gtk.Window):
                 self.set_default_size(int(size[0]), int(size[1]))
             except ValueError as e:
                 log.warning('Invalid size configuration for task %s: %s',
-                            self.task.get_id(), size)
+                            self.task.id, size)
 
     # Can be called at any time to reflect the status of the Task
     # Refresh should never interfere with the TaskView.


### PR DESCRIPTION
Usage of the old `Task.get_id` function leads to a crash when pressing Esc to close the editor.