### PR TITLE
Update task filter on status change

### DIFF
--- a/GTG/gtk/browser/task_pane.py
+++ b/GTG/gtk/browser/task_pane.py
@@ -388,6 +388,7 @@ class TaskPane(Gtk.ScrolledWindow):
             task.toggle_active()
         
         task.notify('is_active')
+        self.task_filter.changed(Gtk.FilterChange.DIFFERENT)
 
 
     def task_setup_cb(self, factory, listitem, user_data=None):


### PR DESCRIPTION
This makes a task immediately "disappear" when clicking its checkbox.