### PR TITLE
Remove redundant 'added' signal when creating task

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -757,7 +757,6 @@ class TaskStore(BaseStore):
         else:
             self.add(task)
 
-        self.emit('added', task)
         return task
 
 
@@ -894,7 +893,7 @@ class TaskStore(BaseStore):
         return root
 
     def add(self, item: Any, parent_id: UUID = None) -> None:
-        """Add a tag to the tagstore."""
+        """Add a task to the taskstore."""
 
         super().add(item, parent_id)
 


### PR DESCRIPTION
I was looking at #21 and I noticed that when creating a new task we do:
```
        if parent:
            self.add(task, parent)
        else:
            self.add(task)

        self.emit('added', task)
```
`self.add()` already emits the 'added' signal, so it doesn't seem necessary here.

Also fixed a typo in a docstring.