### PR TITLE
Remove task from ListStore when removing it from TaskStore

### DIFF
--- a/GTG/core/tasks.py
+++ b/GTG/core/tasks.py
@@ -911,6 +911,11 @@ class TaskStore(BaseStore):
     def remove(self, item_id: UUID) -> None:
         """Remove an existing task."""
 
+        # Remove from UI
+        item = self.lookup[item_id]
+        pos = self.model.find(item)
+        self.model.remove(pos[1])
+
         super().remove(item_id)
 
         self.notify('task_count_all')
@@ -920,10 +925,11 @@ class TaskStore(BaseStore):
     def parent(self, item_id: UUID, parent_id: UUID) -> None:
 
         super().parent(item_id, parent_id)
+
+        # Remove from UI
         item = self.lookup[item_id]
         pos = self.model.find(item)
         self.model.remove(pos[1])
-
 
 
     def unparent(self, item_id: UUID, parent_id: UUID) -> None:

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -886,6 +886,10 @@ class TaskEditor(Gtk.Window):
         tid = self.task.id
 
         if self.is_new():
+            # Remove task from the ListStore
+            pos = self.app.ds.tasks.model.find(self.task)
+            self.app.ds.tasks.model.remove(pos[1])
+
             self.app.ds.tasks.remove(tid)
         else:
             self.save()

--- a/GTG/gtk/editor/editor.py
+++ b/GTG/gtk/editor/editor.py
@@ -886,10 +886,6 @@ class TaskEditor(Gtk.Window):
         tid = self.task.id
 
         if self.is_new():
-            # Remove task from the ListStore
-            pos = self.app.ds.tasks.model.find(self.task)
-            self.app.ds.tasks.model.remove(pos[1])
-
             self.app.ds.tasks.remove(tid)
         else:
             self.save()


### PR DESCRIPTION
Fixes #21

`add()` did `self.model.append()`; now `remove()` does `self.model.remove()`.

Note that I'm not a fan of having the ListStore being a member of TaskStore, because here we're effectively modifying the UI from the datastore, instead of building the UI from the datastore. Probably something to look at after this megbranch gets merged?